### PR TITLE
Fix missing table header bg color in Library Themes section of demo

### DIFF
--- a/src/common/components/Row.js
+++ b/src/common/components/Row.js
@@ -38,6 +38,8 @@ const RowContainer = React.forwardRef((props, ref) => {
 const headerRowContainerStyle = `
   ${baseStyle}
 
+  background-color: ${COLORS.BACKGROUND};
+  
   border-bottom: 1px solid ${COLORS.BORDER};
 
   font-size: 18px;


### PR DESCRIPTION
For some reason every other example in the `Library Themes` section is missing its `th` `background-color`:

https://user-images.githubusercontent.com/1605754/125167972-d5845500-e168-11eb-9af8-001af339309b.mp4

This change just adds the rule explicitly to `headerRowContainerStyle`, the same as it is in `rowContainerStyle`:

https://user-images.githubusercontent.com/1605754/125167973-d6b58200-e168-11eb-8763-5ecacbb71585.mp4

---------------------------------------

Note: There was also a build error when running `npm run storybook:dev` 

`Module not found: Error: Can't resolve 'styled-components'` 

...which can be fixed by running `npm i styled-components`, but I've left that out of this PR in case you wanted to handle it differently.