### PR TITLE
docs: typo in material ui footer

### DIFF
--- a/.storybook/stories/Themes/Libraries/material-ui/native.js
+++ b/.storybook/stories/Themes/Libraries/material-ui/native.js
@@ -113,7 +113,7 @@ const Component = () => {
       <CompactTable columns={COLUMNS} tableOptions={TABLE_OPTIONS} data={data} theme={theme} />
 
       <br />
-      <DocumentationSee noLink anchor={"Mantine's official documentation"} />
+      <DocumentationSee noLink anchor={"Material UI's official documentation"} />
     </>
   );
 };
@@ -234,7 +234,7 @@ const Component = () => {
       <CompactTable columns={COLUMNS} tableOptions={TABLE_OPTIONS} data={data} theme={theme} />
 
       <br />
-      <DocumentationSee noLink anchor={"Mantine's official documentation"} />
+      <DocumentationSee noLink anchor={"Material UI's official documentation"} />
     </>
   );
 };


### PR DESCRIPTION
Thanks for this library. I'm using it on a project now!

I noticed this while wiring up a MUI table and thought perhaps I'd selected the incorrect theme. Instead it was a typo. Here's a fix. Thanks again.
