### PR TITLE
fix(types/pagination)

### DIFF
--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -13,7 +13,11 @@ export type PaginationFunctions = {
 };
 
 export type Pagination<T extends TableNode> = {
-  state: State;
+  state: State & {
+    getTotalPages: (nodes: Array<T>) => number;
+    getPages: (nodes: Array<T>) => Array<T>;
+    getPageBoundaries: (nodes: Array<T>) => { start: number; end: number };
+  };
   fns: PaginationFunctions;
   options: PaginationOptionsSound;
   modifier: Modifier<T>;


### PR DESCRIPTION
Added the declarations for the functions to the "state and getters" object in the [following lines](https://github.com/table-library/react-table-library/blob/3b0ddab82cf7c633731087ba9534020ec9099db2/src/pagination/usePagination.ts#L136C1-L141C5)

```src/pagination/usePagination.ts
  // src/pagination/usePagination.ts
  const stateAndGetters = {
    ...state,
    getTotalPages,
    getPages,
    getPageBoundaries,
  };
```

So that you can get full type support when doing `pagination.state.getPages(data.nodes).map(...)`.