### PR TITLE
fix(HeaderCell): add unique keys to column grouping cells and update …

### DIFF
--- a/.storybook/stories/Misc/Footer/base.jsx
+++ b/.storybook/stories/Misc/Footer/base.jsx
@@ -30,6 +30,16 @@ const Component = () => {
               <HeaderCell>Complete</HeaderCell>
               <HeaderCell>Tasks</HeaderCell>
             </HeaderRow>
+
+            <HeaderRow>
+              <HeaderCell
+                style={{ color: 'gray', fontWeight: 400 }}
+                gridColumnStart={1}
+                gridColumnEnd={6}
+              >
+                The spanned header cell that contains a large sentence
+              </HeaderCell>
+            </HeaderRow>
           </Header>
 
           <Body>

--- a/src/table/Cell/HeaderCell.tsx
+++ b/src/table/Cell/HeaderCell.tsx
@@ -141,8 +141,8 @@ export const HeaderCell: React.FC<HeaderCellProps> = ({
       </HeaderCellContainer>
 
       {/* column grouping */}
-      {Array.from({ length: colSpan }, () => (
-        <HeaderCellContainer className={cs('th', 'hide', 'colspan')} />
+      {Array.from({ length: colSpan }, (_, i) => (
+        <HeaderCellContainer key={`colspan-${i}`} className={cs('th', 'hide', 'colspan')} />
       ))}
     </>
   );


### PR DESCRIPTION
This PR fixes the React warning "Each child in a list should have a unique 'key' prop" that occurs when using the gridColumnStart and gridColumnEnd props in the HeaderCell component (which is also used in FooterCell). The issue was due to the generation of additional grouping cells without unique keys.

Changes:

Updated the column grouping rendering in HeaderCell to assign a unique key to each generated grouping cell.
Updated the Storybook component to validate and demonstrate the fix.
This change addresses #167 