### PR TITLE
feat(Virtualized): propagate onItemsRendered prop

### DIFF
--- a/src/types/virtualized.ts
+++ b/src/types/virtualized.ts
@@ -5,6 +5,15 @@ import { TableOptions, RowOptions } from '@table-library/react-table-library/typ
 
 export type RowHeight = number | ((item: TableNode, index: number) => number);
 
+export type ListOnRowsRenderedParams = {
+  overscanStartIndex: number;
+  overscanStopIndex: number;
+  visibleStartIndex: number;
+  visibleStopIndex: number;
+}
+
+export type OnItemsRendered = (props: ListOnRowsRenderedParams) => any;
+
 export type VirtualizedProps<T extends TableNode> = {
   tableList: T[];
   rowHeight: RowHeight;
@@ -12,4 +21,5 @@ export type VirtualizedProps<T extends TableNode> = {
   body: (node: T, index: number) => React.ReactNode;
   tableOptions?: TableOptions;
   rowOptions?: RowOptions<T>;
+  onItemsRendered?: OnItemsRendered;
 };

--- a/src/virtualized/Virtualized.tsx
+++ b/src/virtualized/Virtualized.tsx
@@ -17,6 +17,7 @@ const Virtualized = <T extends TableNode>({
   body,
   tableOptions,
   rowOptions,
+  onItemsRendered
 }: VirtualizedProps<T>) => {
   return (
     <>
@@ -46,6 +47,7 @@ const Virtualized = <T extends TableNode>({
               </div>
             ))}
             itemData={{ items: tableList }}
+            onItemsRendered={onItemsRendered}
           >
             {({ index, style, data }) => (
               <div


### PR DESCRIPTION
This pull request introduces support for tracking which rows are visible in the virtualized table component. The main change is the addition of an `onItemsRendered` callback, allowing consumers to be notified about the visible and overscanned row indices. This is useful for features like lazy loading, analytics, or dynamic UI updates based on visible rows.

**Virtualization API enhancements:**

* Added a new `ListOnRowsRenderedParams` type and an `OnItemsRendered` callback type to `src/types/virtualized.ts`, enabling detailed tracking of visible and overscan row indices.
* Extended the `VirtualizedProps` interface with an optional `onItemsRendered` prop to allow users to pass a callback.
* Updated the `Virtualized` component to accept and forward the `onItemsRendered` prop, wiring it to the underlying virtualized list implementation. [[1]](diffhunk://#diff-0c62fb778be5f2ee86f6eefaf3edd687f374fd63e64f064fef3e4dd65a4638caR20) [[2]](diffhunk://#diff-0c62fb778be5f2ee86f6eefaf3edd687f374fd63e64f064fef3e4dd65a4638caR50)